### PR TITLE
fix: inchi prefix and missing values added to Proteosafe object

### DIFF
--- a/chemwalker/gnps.py
+++ b/chemwalker/gnps.py
@@ -55,6 +55,9 @@ class Proteosafe:
             url_to_spectra = "http://gnps.ucsd.edu/ProteoSAFe/DownloadResultFile?task=%s&block=main&file=spec/" % (taskid[0])
             self.gnps = pd.read_csv(io.StringIO(requests.get(url_to_attributes).text), sep='\t')
             self.dbmatch = pd.read_csv(io.StringIO(requests.get(url_to_db).text), sep='\t')
+            self.dbmatch = self.dbmatch.dropna(subset = ["INCHI"]).loc[(self.dbmatch.INCHI != " ") & (self.dbmatch.INCHI != "")]
+            self.dbmatch["INCHI"] = self.dbmatch.INCHI.str.strip('"')
+            self.dbmatch["INCHI"] = ["InChI=" + x if not x.startswith("InChI=") else x for x in self.dbmatch.INCHI.to_list()]
             self.net = pd.read_csv(io.StringIO(requests.get(url_to_edges).text), sep='\t')
             self.feat = pd.read_csv(io.StringIO(requests.get(url_to_features).text))
             self.meta = pd.read_csv(io.StringIO(requests.get(url_to_metadata).text), sep='\t')
@@ -74,6 +77,9 @@ class Proteosafe:
             url_to_spectra = "http://gnps.ucsd.edu/ProteoSAFe/DownloadResultFile?task=%s&block=main&file=spectra/specs_ms.mgf" % (taskid[0])
             self.gnps = pd.read_csv(io.StringIO(requests.get(url_to_attributes).text), sep='\t')
             self.dbmatch = pd.read_csv(io.StringIO(requests.get(url_to_db).text), sep='\t')
+            self.dbmatch = self.dbmatch.dropna(subset = ["INCHI"]).loc[(self.dbmatch.INCHI != " ") & (self.dbmatch.INCHI != "")]
+            self.dbmatch["INCHI"] = self.dbmatch.INCHI.str.strip('"')
+            self.dbmatch["INCHI"] = ["InChI=" + x if not x.startswith("InChI=") else x for x in self.dbmatch.INCHI.to_list()]
             self.net = pd.read_csv(io.StringIO(requests.get(url_to_edges).text), sep='\t')
             self.spectra = read_spectra(url_to_spectra)
             if len(taskid) > 1:


### PR DESCRIPTION
A fresh pull request to celebrate CW publication 😄
I worked on the issues that raised an error in the walk_conn_comp. For some reason some Inchis on the self.dbmatch dataframe presented irregularities so I added 3 lines of code in gnsp.py in the proteosafe class. They strip quotation marks in inchi data, drop lines with missing values in INCHI column and add the prefix "InChI=" where it's needed.
I tested the new version with this job that used to couse problems and now it seems ok: 964e82c7b66d45adaa9909e45c36c028

Congrats and thank you for the paper. 

_toco's first round is on me_