### PR TITLE
added openjdk18 to conda environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
   - bioconda
   - defaults
 dependencies:
+  - openjdk>=18
   - pip>=23.2
   - python>=3.10
   - rdkit


### PR DESCRIPTION
Added the openjdk so no local installation of java is needed to run metfrag.